### PR TITLE
no function clause matching in TesseractOcr.read/2 when wrong argumen…

### DIFF
--- a/lib/tesseract_ocr.ex
+++ b/lib/tesseract_ocr.ex
@@ -13,7 +13,7 @@ defmodule TesseractOcr do
       "world"
 
   """
-  def read(path, options \\ %{}) do
+  def read(path, options \\ %{}) when is_binary(path) do
     # #{lang} #{oem} #{psm} #{tessdata_dir} #{user_words} #{user_patterns} #{config_file} #{clear_console_output} #{options_cmd.join(' ')}
     path
     |> command(options)


### PR DESCRIPTION
```
res = get_file() # {:ok, "myfile.png"}
TesseractOcr.read(res)
```

returns 

```
** (exit) an exception was raised:
    ** (ArgumentError) all arguments for System.cmd/3 must be binaries
        (elixir 1.10.0) lib/system.ex:786: System.cmd/3
        (tesseract_ocr 0.1.1) lib/tesseract_ocr.ex:19: TesseractOcr.read/2
        (filet 0.1.0) lib/filet_web/controllers/api/v1/file_controller.ex:42: FiletWeb.Api.V1.FileController.ocr/2
        (filet 0.1.0) lib/filet_web/controllers/api/v1/file_controller.ex:1: FiletWeb.Api.V1.FileController.action/2
        (filet 0.1.0) lib/filet_web/controllers/api/v1/file_controller.ex:1: FiletWeb.Api.V1.FileController.phoenix_controller_pipeline/2
        (phoenix 1.4.13) lib/phoenix/router.ex:288: Phoenix.Router.__call__/2
        (filet 0.1.0) lib/filet_web/endpoint.ex:1: FiletWeb.Endpoint.plug_builder_call/2
        (filet 0.1.0) lib/plug/debugger.ex:130: FiletWeb.Endpoint."call (overridable 3)"/2
```

I know that the documentation is explicit about what arguments should be passed but I spent some times finding what wrongs in the library because the error happened in a sub function.

Adding function gard give a much explicit error

```
** (exit) an exception was raised:
    ** (FunctionClauseError) no function clause matching in TesseractOcr.read/2
        (tesseract_ocr 0.1.1) lib/tesseract_ocr.ex:16: TesseractOcr.read({:ok, "/var/folders/g_/xp7_l6g93sd85vx_9vcs0fv80000gn/T/f-1582281308-26160-1929d7f"}, %{})
        (filet 0.1.0) lib/filet_web/controllers/api/v1/file_controller.ex:42: FiletWeb.Api.V1.FileController.ocr/2
        (filet 0.1.0) lib/filet_web/controllers/api/v1/file_controller.ex:1: FiletWeb.Api.V1.FileController.action/2
        (filet 0.1.0) lib/filet_web/controllers/api/v1/file_controller.ex:1: FiletWeb.Api.V1.FileController.phoenix_controller_pipeline/2
        (phoenix 1.4.13) lib/phoenix/router.ex:288: Phoenix.Router.__call__/2
        (filet 0.1.0) lib/filet_web/endpoint.ex:1: FiletWeb.Endpoint.plug_builder_call/2
        (filet 0.1.0) lib/plug/debugger.ex:130: FiletWeb.Endpoint."call (overridable 3)"/2
        (filet 0.1.0) lib/filet_web/endpoint.ex:1: FiletWeb.Endpoint.call/2
```

Best regard