### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ iex> TesseractOcr.read("test/resources/world.png")
 With additional options.
 
 ```elixir
-iex> TesseractOcr.read("test/resources/world.png", %{lang: 'por', psm: 7, oem: 1})
+iex> TesseractOcr.read("test/resources/world.png", %{lang: "por", psm: 7, oem: 1})
 "world"
 ```
 


### PR DESCRIPTION
Just change character list to binary. Otherwise it throws: `%ArgumentError{message: "all arguments for System.cmd/3 must be binaries"}`.