### PR TITLE
Allow multiple -c options and all default tesseract command line options (like dpi…)

### DIFF
--- a/lib/tesseract_ocr/utils.ex
+++ b/lib/tesseract_ocr/utils.ex
@@ -54,6 +54,12 @@ defmodule TesseractOcr.Utils do
     nil
   end
 
+  defp make_short_option(name, value) when is_list(value) do
+    Enum.flat_map(value, fn v ->
+      ["-#{name}", v]
+    end)
+  end
+
   defp make_short_option(name, value) do
     ["-#{name}", value]
   end

--- a/lib/tesseract_ocr/utils.ex
+++ b/lib/tesseract_ocr/utils.ex
@@ -31,7 +31,11 @@ defmodule TesseractOcr.Utils do
       output,
       make_short_option(:l, options[:l] || options[:lang]),
       make_option(:oem, options[:oem]),
+      make_option(:dpi, options[:dpi]),
       make_option(:psm, options[:psm]),
+      make_option("tessdata-dir", options[:tessdata_dir]),
+      make_option("user-patterns", options[:user_patterns]),
+      make_option("user-words", options[:user_words]),
       make_short_option(:c, options[:c])
     ]
     |> List.flatten()

--- a/test/tesseract_ocr/utils_test.exs
+++ b/test/tesseract_ocr/utils_test.exs
@@ -3,19 +3,59 @@ defmodule TesseractOcr.UtilsTest do
   doctest TesseractOcr.Utils
 
   test "command options generate the options to shell command" do
-    assert TesseractOcr.Utils.command_options("test/resources/world.png", "stdout", %{lang: "por", oem: "1"}) ===
+    assert TesseractOcr.Utils.command_options("test/resources/world.png", "stdout", %{
+             lang: "por",
+             oem: "1"
+           }) ===
              ["test/resources/world.png", "stdout", "-l", "por", "--oem", "1"]
 
-    assert TesseractOcr.Utils.command_options("test/resources/world.png", "stdout", %{psm: "1"}) === [
-             "test/resources/world.png",
-             "stdout",
-             "--psm",
-             "1"
-           ]
+    assert TesseractOcr.Utils.command_options("test/resources/world.png", "stdout", %{psm: "1"}) ===
+             [
+               "test/resources/world.png",
+               "stdout",
+               "--psm",
+               "1"
+             ]
 
     assert TesseractOcr.Utils.command_options("test/resources/world.png", "stdout", %{}) === [
              "test/resources/world.png",
              "stdout"
+           ]
+  end
+
+  test "allow multiple -c options" do
+    assert TesseractOcr.Utils.command_options("test/resources/world.png", "stdout", %{
+             lang: "por",
+             oem: "1",
+             c: ["tessedit_char_whitelist=A", "tessedit_do_invert=0"]
+           }) === [
+             "test/resources/world.png",
+             "stdout",
+             "-l",
+             "por",
+             "--oem",
+             "1",
+             "-c",
+             "tessedit_char_whitelist=A",
+             "-c",
+             "tessedit_do_invert=0"
+           ]
+  end
+
+  test "support a single -c option (support the 'old' behaviour)" do
+    assert TesseractOcr.Utils.command_options("test/resources/world.png", "stdout", %{
+             lang: "por",
+             oem: "1",
+             c: "tessedit_char_whitelist=A"
+           }) === [
+             "test/resources/world.png",
+             "stdout",
+             "-l",
+             "por",
+             "--oem",
+             "1",
+             "-c",
+             "tessedit_char_whitelist=A"
            ]
   end
 end

--- a/test/tesseract_ocr/utils_test.exs
+++ b/test/tesseract_ocr/utils_test.exs
@@ -58,4 +58,38 @@ defmodule TesseractOcr.UtilsTest do
              "tessedit_char_whitelist=A"
            ]
   end
+
+  test "support all default command line options" do
+    assert TesseractOcr.Utils.command_options("test/resources/world.png", "stdout", %{
+             lang: "eng",
+             oem: "1",
+             c: ["tessedit_char_whitelist=A10", "tessedit_do_invert=1"],
+             psm: 3,
+             dpi: 72,
+             tessdata_dir: "/home/tesseract",
+             user_patterns: "/home/tesseract-dir/patterns",
+             user_words: "/home/tesseract-dir/words"
+           }) === [
+             "test/resources/world.png",
+             "stdout",
+             "-l",
+             "eng",
+             "--oem",
+             "1",
+             "--dpi",
+             "72",
+             "--psm",
+             "3",
+             "--tessdata-dir",
+             "/home/tesseract",
+             "--user-patterns",
+             "/home/tesseract-dir/patterns",
+             "--user-words",
+             "/home/tesseract-dir/words",
+             "-c",
+             "tessedit_char_whitelist=A10",
+             "-c",
+             "tessedit_do_invert=1"
+           ]
+  end
 end


### PR DESCRIPTION
Tesseract allows the -c option to be defined multiple times

[tesseract-ocr help](https://digi.bib.uni-mannheim.de/tesseract/manuals/tesseract.1.html)

```bash
-c CONFIGVAR=VALUE
Set value for parameter CONFIGVAR to VALUE. Multiple -c arguments are allowed.
```

This pull request allows to either supply a single c option (backwards compatible) or a list 

```elixir
%{
  lang: "por",
  oem: "1",
  c: "tessedit_char_whitelist=A"
})
```
```elixir
%{
  lang: "por",
  oem: "1",
  c: ["tessedit_char_whitelist=A", "tessedit_do_invert=0"]
})
```